### PR TITLE
Update bundle.md

### DIFF
--- a/docs/item/bundle.md
+++ b/docs/item/bundle.md
@@ -15,7 +15,7 @@ description: "バンドル について"
 
 ↓の画像のようにして作ることができます。
 
-![CraftRecipe](https://cdn.discordapp.com/attachments/528252546423455764/796230275947692092/unknown.png)
+![CraftRecipe](https://i.imgur.com/pmu68Cl.png)
 
 
 ## どうやって使うの？


### PR DESCRIPTION
#154 に対しての暫定的措置で、Discordの直リンクからimgurを使用するように変更しました。